### PR TITLE
Fix image copying

### DIFF
--- a/src/Shapeshifter.UserInterface.WindowsDesktop/Controls/Clipboard/Unwrappers/GeneralUnwrapper.cs
+++ b/src/Shapeshifter.UserInterface.WindowsDesktop/Controls/Clipboard/Unwrappers/GeneralUnwrapper.cs
@@ -16,7 +16,8 @@ namespace Shapeshifter.UserInterface.WindowsDesktop.Controls.Clipboard.Unwrapper
                 ClipboardApi.CF_DSPBITMAP,
                 ClipboardApi.CF_DSPENHMETAFILE,
                 ClipboardApi.CF_ENHMETAFILE,
-                ClipboardApi.CF_METAFILEPICT
+                ClipboardApi.CF_METAFILEPICT,
+                ClipboardApi.CF_BITMAP
             };
         }
 


### PR DESCRIPTION
Add `ClipboardApi.CF_BITMAP` so this is not picked up by `GeneralUnwrapper` to Fix #50