### PR TITLE
Fix #95 initial clipboard data

### DIFF
--- a/src/Shapeshifter.Tests/Mediators/ClipboardUserInterfaceMediatorTest.cs
+++ b/src/Shapeshifter.Tests/Mediators/ClipboardUserInterfaceMediatorTest.cs
@@ -240,9 +240,7 @@
                         });
                     fakePackage.Control.Returns(fakeControl);
 
-                    c.RegisterFake<IClipboardDataControlPackageFactory>(
-                        
-                        )
+                    c.RegisterFake<IClipboardDataControlPackageFactory>()
                      .CreateFromCurrentClipboardData()
                      .Returns(fakePackage);
                 });

--- a/src/Shapeshifter.Tests/Mediators/ClipboardUserInterfaceMediatorTest.cs
+++ b/src/Shapeshifter.Tests/Mediators/ClipboardUserInterfaceMediatorTest.cs
@@ -155,6 +155,7 @@
                 c => {
                     c.RegisterFake<IClipboardCopyInterceptor>();
                     c.RegisterFake<IPasteCombinationDurationMediator>();
+                    c.RegisterFake<IClipboardDataControlPackageFactory>();
                 });
 
             var mediator = container.Resolve<IClipboardUserInterfaceMediator>();
@@ -209,13 +210,14 @@
             var mediator = container.Resolve<IClipboardUserInterfaceMediator>();
             mediator.Connect(null);
 
+            var numberOfPackagesBeforeDataCopied = mediator.ClipboardElements.Count();
             var fakeClipboardHookService = container.Resolve<IClipboardCopyInterceptor>();
             fakeClipboardHookService.DataCopied +=
                 Raise.Event<EventHandler<DataCopiedEventArgument>>(
                     fakeClipboardHookService,
                     new DataCopiedEventArgument());
 
-            Assert.AreEqual(1, mediator.ClipboardElements.Count());
+            Assert.AreEqual(1, mediator.ClipboardElements.Count() - numberOfPackagesBeforeDataCopied);
         }
 
         [TestMethod]
@@ -254,8 +256,8 @@
                     fakeClipboardHookService,
                     new DataCopiedEventArgument());
 
-            var addedPackage = mediator.ClipboardElements.Single();
-            var content = addedPackage.Data.Contents.Single();
+            var addedPackage = mediator.ClipboardElements.Last();
+            var content = addedPackage.Data.Contents.Last();
             Assert.AreSame(fakeData, content);
             Assert.AreSame(fakeControl, addedPackage.Control);
         }
@@ -288,7 +290,7 @@
                     fakeClipboardHookService,
                     new DataCopiedEventArgument());
 
-            var addedPackage = mediator.ClipboardElements.Single();
+            var addedPackage = mediator.ClipboardElements.Last();
             Assert.IsNotNull(addedPackage);
 
             Assert.AreSame(mediator, eventSender);

--- a/src/Shapeshifter.WindowsDesktop/Mediators/ClipboardUserInterfaceMediator.cs
+++ b/src/Shapeshifter.WindowsDesktop/Mediators/ClipboardUserInterfaceMediator.cs
@@ -132,8 +132,14 @@
                     "The user interface mediator is already connected.");
             }
 
+            LoadInitialClipboardData();
             InstallClipboardHook();
             InstallPastecombinationDurationMediator(targetWindow);
+        }
+
+        void LoadInitialClipboardData()
+        {
+            AppendPackagesWithDataFromClipboard();
         }
 
         void InstallPastecombinationDurationMediator(IWindow targetWindow)

--- a/src/Shapeshifter.WindowsDesktop/Mediators/ClipboardUserInterfaceMediator.cs
+++ b/src/Shapeshifter.WindowsDesktop/Mediators/ClipboardUserInterfaceMediator.cs
@@ -64,6 +64,11 @@
             object sender,
             DataCopiedEventArgument e)
         {
+            AppendPackagesWithDataFromClipboard();
+        }
+
+        void AppendPackagesWithDataFromClipboard()
+        {
             var package = clipboardDataControlPackageFactory.CreateFromCurrentClipboardData();
             if (package == null)
             {


### PR DESCRIPTION
This makes `ClipboardUserInterfaceMediator` load what's in the clipboard when it's `Connect(...)`'ed.