### PR TITLE
Add Quiet Mode

### DIFF
--- a/src/Shapeshifter.Tests/Services/SettingsManagerTest.cs
+++ b/src/Shapeshifter.Tests/Services/SettingsManagerTest.cs
@@ -16,13 +16,22 @@
             Assert.AreEqual("foobar", setting);
         }
 
-        [TestMethod]
-        public void CanPersistAndFetchIntegers()
-        {
-            SystemUnderTest.SaveSetting("integer", 1337);
+		[TestMethod]
+		public void CanPersistAndFetchIntegers()
+		{
+			SystemUnderTest.SaveSetting("integer", 1337);
 
-            var setting = SystemUnderTest.LoadSetting<int>("integer");
-            Assert.AreEqual(1337, setting);
-        }
+			var setting = SystemUnderTest.LoadSetting<int>("integer");
+			Assert.AreEqual(1337, setting);
+		}
+
+		[TestMethod]
+		public void CanPersistAndFetchBooleans()
+		{
+			SystemUnderTest.SaveSetting("boolean", true);
+
+			var setting = SystemUnderTest.LoadSetting<bool>("boolean");
+			Assert.AreEqual(true, setting);
+		}
     }
 }

--- a/src/Shapeshifter.WindowsDesktop/Controls/Window/SettingsWindow.xaml
+++ b/src/Shapeshifter.WindowsDesktop/Controls/Window/SettingsWindow.xaml
@@ -16,7 +16,8 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <CheckBox Margin="0,5" IsChecked="{Binding StartWithWindows}" Content="Start with Windows" />
-		<StackPanel Margin="0,5" Grid.Row="1">
+        <CheckBox Margin="0,5" Grid.Row="1" IsChecked="{Binding QuietMode}" Content="Silence copy notifications" />
+		<StackPanel Margin="0,5" Grid.Row="2">
 			<Label>Paste duration before user interface shows up (milliseconds)</Label>
 			<Slider TickFrequency="100" Minimum="0" Maximum="3000" SmallChange="100" Value="{Binding PasteDurationBeforeUserInterfaceShowsInMilliseconds}" TickPlacement="Both" IsSnapToTickEnabled="True" AutoToolTipPlacement="TopLeft" />
 			<controls:NumberTextBox Minimum="0" Maximum="3000" HorizontalAlignment="Center" Text="{Binding PasteDurationBeforeUserInterfaceShowsInMilliseconds}" FontWeight="Bold" />

--- a/src/Shapeshifter.WindowsDesktop/Controls/Window/SettingsWindow.xaml
+++ b/src/Shapeshifter.WindowsDesktop/Controls/Window/SettingsWindow.xaml
@@ -16,7 +16,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <CheckBox Margin="0,5" IsChecked="{Binding StartWithWindows}" Content="Start with Windows" />
-        <CheckBox Margin="0,5" Grid.Row="1" IsChecked="{Binding QuietMode}" Content="Silence copy notifications" />
+        <CheckBox Margin="0,5" Grid.Row="1" IsChecked="{Binding IsQuietModeEnabled}" Content="Silence copy notifications" />
 		<StackPanel Margin="0,5" Grid.Row="2">
 			<Label>Paste duration before user interface shows up (milliseconds)</Label>
 			<Slider TickFrequency="100" Minimum="0" Maximum="3000" SmallChange="100" Value="{Binding PasteDurationBeforeUserInterfaceShowsInMilliseconds}" TickPlacement="Both" IsSnapToTickEnabled="True" AutoToolTipPlacement="TopLeft" />

--- a/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/Interfaces/ISettingsViewModel.cs
+++ b/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/Interfaces/ISettingsViewModel.cs
@@ -9,6 +9,8 @@
     {
         bool StartWithWindows { get; set; }
 
+		bool QuietMode { get; set; }
+
         int PasteDurationBeforeUserInterfaceShowsInMilliseconds { get; set; }
 
         string HotkeyString { get; }

--- a/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/Interfaces/ISettingsViewModel.cs
+++ b/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/Interfaces/ISettingsViewModel.cs
@@ -9,7 +9,7 @@
     {
         bool StartWithWindows { get; set; }
 
-		bool QuietMode { get; set; }
+		bool IsQuietModeEnabled { get; set; }
 
         int PasteDurationBeforeUserInterfaceShowsInMilliseconds { get; set; }
 

--- a/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/SettingsViewModel.cs
+++ b/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/SettingsViewModel.cs
@@ -21,8 +21,9 @@
 
         int pasteDurationBeforeUserInterfaceShowsInMilliseconds;
         string hotkeyString;
+		bool quietMode;
 
-        public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler PropertyChanged;
 
         public SettingsViewModel(
             IRegistryManager registryManager,
@@ -34,6 +35,10 @@
             this.processManager = processManager;
             this.settingsManager = settingsManager;
             this.keyboardManager = keyboardManager;
+
+			quietMode = settingsManager.LoadSetting(
+				nameof(QuietMode),
+				false);
 
             pasteDurationBeforeUserInterfaceShowsInMilliseconds = settingsManager.LoadSetting(
                 nameof(PasteDurationBeforeUserInterfaceShowsInMilliseconds),
@@ -81,7 +86,25 @@
             }
         }
 
-        public int PasteDurationBeforeUserInterfaceShowsInMilliseconds
+		public bool QuietMode
+		{
+			get
+			{
+				return quietMode;
+			}
+			set
+			{
+				if (value == QuietMode) return;
+
+				settingsManager.SaveSetting(
+					nameof(QuietMode),
+					quietMode = value);
+
+				OnPropertyChanged();
+			}
+		}
+
+		public int PasteDurationBeforeUserInterfaceShowsInMilliseconds
         {
             get
             {

--- a/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/SettingsViewModel.cs
+++ b/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/SettingsViewModel.cs
@@ -37,7 +37,7 @@
             this.keyboardManager = keyboardManager;
 
 			quietMode = settingsManager.LoadSetting(
-				nameof(QuietMode),
+				nameof(IsQuietModeEnabled),
 				false);
 
             pasteDurationBeforeUserInterfaceShowsInMilliseconds = settingsManager.LoadSetting(
@@ -86,7 +86,7 @@
             }
         }
 
-		public bool QuietMode
+		public bool IsQuietModeEnabled
 		{
 			get
 			{
@@ -94,10 +94,10 @@
 			}
 			set
 			{
-				if (value == QuietMode) return;
+				if (value == IsQuietModeEnabled) return;
 
 				settingsManager.SaveSetting(
-					nameof(QuietMode),
+					nameof(IsQuietModeEnabled),
 					quietMode = value);
 
 				OnPropertyChanged();

--- a/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/SourceClipboardQuantityOverlayViewModel.cs
+++ b/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/SourceClipboardQuantityOverlayViewModel.cs
@@ -16,6 +16,7 @@ namespace Shapeshifter.WindowsDesktop.Controls.Window.ViewModels
 		readonly IScreenManager screenManager;
 		readonly IThreadDeferrer threadDeferrer;
 		readonly IMainViewModel mainViewModel;
+		readonly ISettingsViewModel settingsViewModel;
 
 		public event EventHandler<DataSourceClipboardQuantityShownEventArgument> ClipboardQuantityShown;
 		public event EventHandler<DataSourceClipboardQuantityHiddenEventArgument> ClipboardQuantityHidden;
@@ -61,11 +62,13 @@ namespace Shapeshifter.WindowsDesktop.Controls.Window.ViewModels
 		public SourceClipboardQuantityOverlayViewModel(
 			IScreenManager screenManager,
 			IThreadDeferrer threadDeferrer,
-			IMainViewModel mainViewModel)
+			IMainViewModel mainViewModel,
+			ISettingsViewModel settingsViewModel)
 		{
 			this.screenManager = screenManager;
 			this.threadDeferrer = threadDeferrer;
 			this.mainViewModel = mainViewModel;
+			this.settingsViewModel = settingsViewModel;
 
 			SetupEvents();
 		}
@@ -77,6 +80,9 @@ namespace Shapeshifter.WindowsDesktop.Controls.Window.ViewModels
 
 		async void UserInterfaceViewModel_UserInterfaceDataControlAdded(object sender, UserInterfaceDataControlAddedEventArgument e)
 		{
+			if (settingsViewModel.QuietMode)
+				return;
+
 			ActiveScreen = screenManager.GetActiveScreen();
 			Source = e.Package.Data.Source;
 			Count = mainViewModel

--- a/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/SourceClipboardQuantityOverlayViewModel.cs
+++ b/src/Shapeshifter.WindowsDesktop/Controls/Window/ViewModels/SourceClipboardQuantityOverlayViewModel.cs
@@ -80,7 +80,7 @@ namespace Shapeshifter.WindowsDesktop.Controls.Window.ViewModels
 
 		async void UserInterfaceViewModel_UserInterfaceDataControlAdded(object sender, UserInterfaceDataControlAddedEventArgument e)
 		{
-			if (settingsViewModel.QuietMode)
+			if (settingsViewModel.IsQuietModeEnabled)
 				return;
 
 			ActiveScreen = screenManager.GetActiveScreen();

--- a/src/Shapeshifter.WindowsDesktop/Shapeshifter.WindowsDesktop.csproj
+++ b/src/Shapeshifter.WindowsDesktop/Shapeshifter.WindowsDesktop.csproj
@@ -97,6 +97,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=4.8.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">


### PR DESCRIPTION
This PR is to add quiet mode as described in [this issue](https://github.com/ffMathy/Shapeshifter/issues/400).

This adds a setting for a "Quiet Mode" which is off by default, and while on prevents the copy notifications from appearing. 

Also changed is the setting of the language version for the WindowsDesktop project release configuration to be the latest minor version. This is to fix an issue I encountered with building release, where the default literal is used (ex. ActiveWindowService.cs:54) but is not available in C#7.0 which was the default language version. Setting release to be latest minor version is consistent with the debug configuration.